### PR TITLE
Provide a more Clojure idiomatic way of using CDK

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
            org.apache.commons/commons-compress {:mvn/version "1.0"}
            org.clojure/data.json               {:mvn/version "0.2.6"}
            software.amazon.jsii/jsii-runtime   {:mvn/version "0.14.2"}
-           org.clojure/tools.deps.alpha        {:mvn/version "0.7.527"}
+           org.clojure/tools.deps.alpha        {:mvn/version "0.7.541"}
            com.amazonaws/aws-lambda-java-core  {:mvn/version "1.2.0"}
            pack/pack.alpha                     {:git/url "https://github.com/juxt/pack.alpha.git"
                                                 :sha     "2769a6224bfb938e777906ea311b3daf7d2220f5"}}

--- a/example-app/cdk/stedi/cdk/app/sample.clj
+++ b/example-app/cdk/stedi/cdk/app/sample.clj
@@ -8,7 +8,7 @@
             ("@aws-cdk/core" Stack))
 
 (defn app-stack [app id]
-  (let [stack (Stack nil id {})]
+  (let [stack (Stack app id {})]
     (Function stack "my-fn"
               {:runtime (:JAVA_8 Runtime)
                :code    (AssetCode "./src")

--- a/example-app/cdk/stedi/cdk/app/sample.clj
+++ b/example-app/cdk/stedi/cdk/app/sample.clj
@@ -1,18 +1,19 @@
 (ns stedi.cdk.app.sample
-  (:require [stedi.cdk :as cdk]
-            [stedi.cdk.lambda :as lambda]
+  (:require [clojure.spec.alpha :as s]
+            [stedi.cdk :as cdk]
+            #_[stedi.cdk.lambda :as lambda]
             [stedi.app.sample :as sample-app]))
 
-(cdk/require ["@aws-cdk/core" cdk-core]
-             ["@aws-cdk/aws-apigateway" apigw])
-
-(cdk/defextension stack cdk-core/Stack
-  :cdk/init
-  (fn [this]
-    (let [function (lambda/clj :cdk/create this "Function"
-                               {:fn #'sample-app/handler})]
-      (apigw/LambdaRestApi :cdk/create this "Api"
-                           {:handler function}))))
-
-(cdk/defapp app [this]
-  (stack :cdk/create this "DevStack"))
+(cdk/require-2 ["@aws-cdk/aws-lambda.Function" function]
+               ["@aws-cdk/aws-lambda.Runtime" runtime]
+               ["@aws-cdk/aws-lambda.AssetCode" asset-code]
+               ["@aws-cdk/core.Stack" stack]
+               ["@aws-cdk/core.App" app]
+               ["@aws-cdk/core.Resource" resource])
+(def app
+  (let [app   (app/create)
+        stack (stack/create app "foobar")]
+    (function/create stack "fn"
+                     {:code    (asset-code/create "./src")
+                      :handler "foo.bar"
+                      :runtime (runtime/JAVA_8)})))

--- a/example-app/cdk/stedi/cdk/app/sample.clj
+++ b/example-app/cdk/stedi/cdk/app/sample.clj
@@ -1,23 +1,20 @@
 (ns stedi.cdk.app.sample
   (:require [clojure.spec.alpha :as s]
             [stedi.cdk :as cdk]
+            [stedi.cdk.lambda :as lambda]
             [stedi.app.sample :as sample-app]))
 
-(cdk/import ("@aws-cdk/aws-lambda" Function Runtime AssetCode)
-            ("@aws-cdk/aws-iam" Effect)
-            ("@aws-cdk/core" Stack))
+(cdk/import ("@aws-cdk/core" Stack)
+            ("@aws-cdk/aws-apigateway" LambdaRestApi))
 
-(defn app-stack [app id]
-  (let [stack (Stack app id {})]
-    (Function stack "my-fn"
-              {:runtime (:JAVA_8 Runtime)
-               :code    (AssetCode "./src")
-               :handler ""})
-    stack))
+(defn AppStack [app id]
+  (let [stack    (Stack app id)
+        function (lambda/Clj stack "function" {:fn #'sample-app/handler})]
+    (LambdaRestApi stack "api" {:handler function})))
 
 (cdk/defapp app
   [this]
-  (app-stack this "test"))
+  (AppStack this "DevStack"))
 
 (comment
   ;; Instantiation:

--- a/example-app/cdk/stedi/cdk/app/sample.clj
+++ b/example-app/cdk/stedi/cdk/app/sample.clj
@@ -20,19 +20,56 @@
   (app-stack this "test"))
 
 (comment
-  (Function stack "my-fn" {}) ;; constructor
-  (:role function)            ;; instance prop
-  (:JAVA_8 Runtime)           ;; static prop
-  (Function/fromFunctionArn)  ;; static method
-  (Function/toString this)    ;; instance method
-  Effect/ALLOW                ;; enum
-  )
+  ;; Instantiation:
 
-#_(def app
-  (let [app   (app/create)
-        stack (stack/create app "foobar")]
-    (function/create stack "fn"
-                     {:code    (asset-code/create "./src")
-                      :handler "foo.bar"
-                      :runtime (runtime/JAVA_8)})
-    app))
+  ;; old
+  (cdk/require ["@aws-cdk/aws-lambda" lambda])
+  (lambda/Function :cdk/create stack "myfn" {})
+
+  ;; new
+  (cdk/import ("@aws-cdk/aws-lambda" Function))
+  (Function stack "my-fn" {})
+
+  ;; Instance Properties (unchanged):
+  (:role function)
+
+  ;; Static Properties:
+
+  ;; old
+  (cdk/require ["@aws-cdk/aws-lambda" lambda])
+  (:JAVA_8 lambda/Runtime)
+
+  ;; new
+  (cdk/import ("@aws-cdk/aws-lambda" Runtime))
+  (:JAVA_8 Runtime)
+
+
+  ;; Static Methods:
+
+  ;; old
+  (cdk/require ["@aws-cdk/core" cdk-core])
+  (cdk-core/Duration :minutes 5)
+
+  ;; new
+  (cdk/import ("@aws-cdk/core" Duration))
+  (Duration/minutes 5)
+
+  ;; Instance Methods:
+
+  ;; old
+  (function :addEnvironment "key" "value")
+
+  ;; new
+  (cdk/import ("@aws-cdk/aws-lambda" Function))
+  (Function/addEnvironment function "key" "value")
+
+  ;; Enums:
+
+  ;; old
+  (cdk/require ["@aws-cdk/aws-iam" iam])
+  (iam/Effect :cdk/enum :ALLOW)
+
+  ;; new
+  (cdk/import ("@aws-cdk/aws-iam" Effect))
+  Effect/ALLOW
+  )

--- a/example-app/cdk/stedi/cdk/app/sample.clj
+++ b/example-app/cdk/stedi/cdk/app/sample.clj
@@ -1,19 +1,38 @@
 (ns stedi.cdk.app.sample
   (:require [clojure.spec.alpha :as s]
             [stedi.cdk :as cdk]
-            #_[stedi.cdk.lambda :as lambda]
             [stedi.app.sample :as sample-app]))
 
-(cdk/require-2 ["@aws-cdk/aws-lambda.Function" function]
-               ["@aws-cdk/aws-lambda.Runtime" runtime]
-               ["@aws-cdk/aws-lambda.AssetCode" asset-code]
-               ["@aws-cdk/core.Stack" stack]
-               ["@aws-cdk/core.App" app]
-               ["@aws-cdk/core.Resource" resource])
-(def app
+(cdk/import ("@aws-cdk/aws-lambda" Function Runtime AssetCode)
+            ("@aws-cdk/aws-iam" Effect)
+            ("@aws-cdk/core" Stack))
+
+(defn app-stack [app id]
+  (let [stack (Stack nil id {})]
+    (Function stack "my-fn"
+              {:runtime (:JAVA_8 Runtime)
+               :code    (AssetCode "./src")
+               :handler ""})
+    stack))
+
+(cdk/defapp app
+  [this]
+  (app-stack this "test"))
+
+(comment
+  (Function stack "my-fn" {}) ;; constructor
+  (:role function)            ;; instance prop
+  (:JAVA_8 Runtime)           ;; static prop
+  (Function/fromFunctionArn)  ;; static method
+  (Function/toString this)    ;; instance method
+  Effect/ALLOW                ;; enum
+  )
+
+#_(def app
   (let [app   (app/create)
         stack (stack/create app "foobar")]
     (function/create stack "fn"
                      {:code    (asset-code/create "./src")
                       :handler "foo.bar"
-                      :runtime (runtime/JAVA_8)})))
+                      :runtime (runtime/JAVA_8)})
+    app))

--- a/src/stedi/cdk.clj
+++ b/src/stedi/cdk.clj
@@ -23,12 +23,9 @@
       (import/import-as-namespace fqn alias*))))
 
 (defmacro ^:deprecated require
-  "Require's jsii modules and binds them to an alias. Allows for
-  multiple module requirement bindings.
-
-  Example:
-  
-  (cdk/require [\"@aws-cdk/aws-lambda\" lambda])"
+  "
+  Deprecated in favor of `stedi.cdk/import`
+  "
   [& package+alias]
   (doseq [[package alias*] package+alias]
     (client/load-module package)
@@ -44,19 +41,9 @@
       (alias alias* ns-sym))))
 
 (defmacro ^:deprecated defextension
-  "Extends an existing cdk class. Right now the only extension allowed
-  is :cdk/init which allows the initialization behavior to be
-  specified.
-
-  Example:
-
-  (cdk/require [\"@aws-cdk/core\" aws-core]
-               [\"@aws-cdk/aws-s3\" aws-s3])
-
-  (cdk/defextension stack cdk-core/Stack
-    :cdk/init
-    (fn [this]
-      (aws-s3/bucket this \"MyBucket\" {})))"
+  "
+  Deprecated in favor of using regular clojure functions.
+  "
   [name cdk-class & override+fns]
   (let [fqn       (-> cdk-class (resolve) (meta) (:cdk/fqn))
         overrides (into {}

--- a/src/stedi/cdk.clj
+++ b/src/stedi/cdk.clj
@@ -39,7 +39,7 @@
     (intern ns-sym
             (with-meta (symbol name)
               {:doc      (render-docs docs)
-               :arglists (list (mapv (comp symbol :name) parameters))})
+               :arglists (list (vec (cons 'this (mapv (comp symbol :name) parameters))))})
             (fn [this & args]
               (apply this (keyword name) args)))))
 

--- a/src/stedi/cdk.clj
+++ b/src/stedi/cdk.clj
@@ -45,6 +45,7 @@
 
 (defn- intern-initializer
   [{:keys [ns-sym fqn parameters docs alias*] :as args}]
+  (ns-unmap *ns* alias*)
   (intern *ns*
           (with-meta alias*
             {:arglists (list (mapv (comp symbol :name) parameters))

--- a/src/stedi/cdk/impl.clj
+++ b/src/stedi/cdk/impl.clj
@@ -55,6 +55,18 @@
   (invoke [this op a b c]
     (invoke-object this op a b c))
 
+  clojure.lang.Seqable
+  (seq [this]
+    (seq
+      (into {} (comp (remove :static)
+                     (map (comp keyword :name))
+                     (map #(vector % (% this))))
+            (:properties (doc-data (.getFqn object-ref))))))
+
+  clojure.lang.IPersistentCollection
+  (cons [this x] this)
+  (empty [this] this)
+
   java.lang.Object
   (toString [this] (invoke-object this :toString)))
 
@@ -115,6 +127,14 @@
 
       (-> (client/get-static-property-value fqn (name k))
           (wrap-objects))))
+
+  clojure.lang.Seqable
+  (seq [this]
+    (seq
+      (into {} (comp (filter :static)
+                     (map (comp keyword :name))
+                     (map #(vector % (% this))))
+            (:properties (doc-data fqn)))))
 
   clojure.lang.IFn
   (applyTo [this arg-list]

--- a/src/stedi/cdk/impl.clj
+++ b/src/stedi/cdk/impl.clj
@@ -55,18 +55,6 @@
   (invoke [this op a b c]
     (invoke-object this op a b c))
 
-  clojure.lang.Seqable
-  (seq [this]
-    (seq
-      (into {} (comp (remove :static)
-                     (map (comp keyword :name))
-                     (map #(vector % (% this))))
-            (:properties (doc-data (.getFqn object-ref))))))
-
-  clojure.lang.IPersistentCollection
-  (cons [this x] this)
-  (empty [this] this)
-
   java.lang.Object
   (toString [this]
     (try
@@ -131,14 +119,6 @@
 
       (-> (client/get-static-property-value fqn (name k))
           (wrap-objects))))
-
-  clojure.lang.Seqable
-  (seq [this]
-    (seq
-      (into {} (comp (filter :static)
-                     (map (comp keyword :name))
-                     (map #(vector % (% this))))
-            (:properties (doc-data fqn)))))
 
   clojure.lang.IFn
   (applyTo [this arg-list]

--- a/src/stedi/cdk/impl.clj
+++ b/src/stedi/cdk/impl.clj
@@ -95,16 +95,17 @@
 
 (defn invoke-class
   [cdk-class op & args]
-  (assert (keyword? op) "op must be a keyword")
-  (let [fqs       (. cdk-class fqs)
-        fqn       (. cdk-class fqn)
-        overrides (some-> fqs resolve meta ::overrides)]
-    (case op
-      :cdk/create (create-object cdk-class overrides args)
-      :cdk/browse (browse-docs fqn)
-      :cdk/enum   {"$jsii.enum" (str fqn "/" (name (first args)))}
+  (if (keyword? op)
+    (let [fqs       (. cdk-class fqs)
+          fqn       (. cdk-class fqn)
+          overrides (some-> fqs resolve meta ::overrides)]
+      (case op
+        :cdk/create (create-object cdk-class overrides args)
+        :cdk/browse (browse-docs fqn)
+        :cdk/enum   {"$jsii.enum" (str fqn "/" (name (first args)))}
 
-      (wrap-objects (client/call-static-method fqn (name op) (unwrap-objects args))))))
+        (wrap-objects (client/call-static-method fqn (name op) (unwrap-objects args)))))
+    (create-object cdk-class {} (concat [op] args))))
 
 (deftype CDKClass [fqn fqs]
   clojure.lang.ILookup

--- a/src/stedi/cdk/impl.clj
+++ b/src/stedi/cdk/impl.clj
@@ -68,7 +68,11 @@
   (empty [this] this)
 
   java.lang.Object
-  (toString [this] (invoke-object this :toString)))
+  (toString [this]
+    (try
+      (invoke-object this :toString)
+      (catch Exception _
+        (.getFqn object-ref)))))
 
 (defn wrap-objects
   [x]

--- a/src/stedi/cdk/import.clj
+++ b/src/stedi/cdk/import.clj
@@ -1,0 +1,88 @@
+(ns stedi.cdk.import
+  "For internal use only. Implementation for import api."
+  (:require [clojure.walk :as walk]
+            [stedi.cdk.impl :as impl]
+            [stedi.cdk.jsii.client :as client]))
+
+(defn- render-docs [docs]
+  (str "\nStability: [" (:stability docs) "]"
+       "\n\n"
+       "Summary:\n\n"
+       (:summary docs)
+       "\n\n"
+       "Remarks:\n\n"
+       (:remarks docs)))
+
+(defn- fqn->module
+  [fqn]
+  (-> fqn (clojure.string/split #"\.") (first)))
+
+(defn- manifest [fqn]
+  (-> fqn
+      (fqn->module)
+      (client/get-manifest)
+      (get-in ["types" fqn])
+      (walk/keywordize-keys)))
+
+(defn- intern-method
+  [{:keys [static parameters docs name ns-sym fqn]}]
+  (if static
+    (intern ns-sym
+            (with-meta (symbol name)
+              {:doc      (render-docs docs)
+               :arglists (list (mapv (comp symbol :name) parameters))})
+            (fn [& args]
+              (client/call-static-method fqn name args)))
+    (intern ns-sym
+            (with-meta (symbol name)
+              {:doc      (render-docs docs)
+               :arglists (list (vec (cons 'this (mapv (comp symbol :name) parameters))))})
+            (fn [this & args]
+              (apply this (keyword name) args)))))
+
+(defn- intern-initializer
+  [{:keys [ns-sym fqn parameters docs alias*] :as args}]
+  (ns-unmap *ns* alias*)
+  (intern *ns*
+          (with-meta alias*
+            {:arglists (list (mapv (comp symbol :name) parameters))
+             :doc      (with-out-str
+                         (println)
+                         (clojure.pprint/pprint (manifest fqn)))})
+          (impl/wrap-class fqn nil)))
+
+(defn- intern-enum-member
+  [{:keys [ns-sym name fqn]}]
+  (intern ns-sym
+          (symbol name)
+          {"$jsii.enum" (str fqn "/" name)}))
+
+(defn- classes [fqn]
+  (let [manifest* (manifest fqn)]
+    (lazy-cat [manifest*]
+              (when-let [base (:base manifest*)]
+                (classes base)))))
+
+(defn import-as-namespace
+  [fqn alias*]
+  (let [module         (fqn->module fqn)
+        module-ns      (-> fqn (impl/package->ns-sym) (create-ns))
+        ns-sym         (ns-name module-ns)
+        _              (client/load-module module)
+        {:keys [initializer
+                members
+                docs]} (manifest fqn)]
+    (doseq [method (mapcat :methods (reverse (classes fqn)))]
+      (intern-method (merge method
+                            {:ns-sym ns-sym
+                             :fqn    fqn})))
+    (intern-initializer (merge initializer
+                               {:ns-sym ns-sym
+                                :fqn    fqn
+                                :docs   docs
+                                :alias* alias*}))
+    (doseq [member members]
+      (intern-enum-member (merge member
+                                 {:ns-sym ns-sym
+                                  :fqn    fqn})))
+    (alias alias* ns-sym)))

--- a/src/stedi/cdk/import.clj
+++ b/src/stedi/cdk/import.clj
@@ -32,7 +32,8 @@
               {:doc      (render-docs docs)
                :arglists (list (mapv (comp symbol :name) parameters))})
             (fn [& args]
-              (client/call-static-method fqn name args)))
+              (let [cdk-class (impl/wrap-class fqn nil)]
+                (apply impl/invoke-class cdk-class (keyword name) args))))
     (intern ns-sym
             (with-meta (symbol name)
               {:doc      (render-docs docs)

--- a/src/stedi/cdk/lambda.clj
+++ b/src/stedi/cdk/lambda.clj
@@ -36,5 +36,5 @@
 
 (defn ^:deprecated clj
   "Deprecated in favor of `stedi.cdk.lambda/Clj`."
-  [parent id {:keys [fn environment handler aot] :as props}]
+  [_ parent id {:keys [fn environment handler aot] :as props}]
   (Clj parent id props))

--- a/src/stedi/cdk/lambda.clj
+++ b/src/stedi/cdk/lambda.clj
@@ -5,27 +5,36 @@
   (:import (java.security MessageDigest)
            (java.util Base64)))
 
-(cdk/require ["@aws-cdk/core" cdk-core]
-             ["@aws-cdk/aws-lambda" lambda])
+(cdk/import ("@aws-cdk/core" Duration)
+            ("@aws-cdk/aws-lambda" Function AssetCode Runtime LayerVersion))
 
-(cdk/defextension clj lambda/Function
-  :cdk/build
-  (fn [constructor parent id {:keys [fn environment handler aot]}]
-    (let [path      (str (get-in parent [:node :path]) "/" id)
-          build-dir (str "./target/" (string/replace path "/" "_"))
-          
-          {:keys [lib-layer aot-layer src]} (impl/build-layers build-dir aot)
+(defn Clj
+  "Wraps `@aws-cdk/aws-clambda.Function` to be clojure friendly.
 
-          function (constructor parent id
-                                {:code        (lambda/Code :cdk/asset src)
-                                 :handler     (or handler "stedi.cdk.lambda.handler::handler")
-                                 :runtime     (:JAVA_8 lambda/Runtime)
-                                 :environment (merge environment
-                                                     (when fn {"STEDI_LAMBDA_ENTRYPOINT" (-> fn symbol str)}))
-                                 :memorySize  2048
-                                 :timeout     (cdk-core/Duration :minutes 1)})]
-      (function :addLayers
-                (lambda/LayerVersion :cdk/create function "lib-layer"
-                                     {:code (lambda/Code :cdk/asset lib-layer)})
-                (lambda/LayerVersion :cdk/create function "class-layer"
-                                     {:code (lambda/Code :cdk/asset aot-layer)})))))
+    fn          - A var pointing to a handler function.
+    environment - A map of environment variables
+    handler     - Only necessary if fn isn't specified
+    aot         - A list of namespaces to AOT compile
+  "
+  [parent id {:keys [fn environment handler aot]}]
+  (let [path                              (str (get-in parent [:node :path]) "/" id)
+        build-dir                         (str "./target/" (string/replace path "/" "_"))
+        {:keys [lib-layer aot-layer src]} (impl/build-layers build-dir aot)
+        function
+        (Function parent id
+                  {:code        (AssetCode src)
+                   :handler     (or handler "stedi.cdk.lambda.handler::handler")
+                   :runtime     (:JAVA_8 Runtime)
+                   :environment (merge environment
+                                       (when fn {"STEDI_LAMBDA_ENTRYPOINT" (-> fn symbol str)}))
+                   :memorySize  2048
+                   :timeout     (Duration/minutes 1)})]
+    (Function/addLayers function
+                        (LayerVersion function "lib-layer" {:code (AssetCode lib-layer)})
+                        (LayerVersion function "class-layer" {:code (AssetCode aot-layer)}))
+    function))
+
+(defn ^:deprecated clj
+  "Deprecated in favor of `stedi.cdk.lambda/Clj`."
+  [parent id {:keys [fn environment handler aot] :as props}]
+  (Clj parent id props))


### PR DESCRIPTION
This backwards compatible change introduces a new syntax that is more idiomatic for Clojure.

Summary of changes:
- Deprecate `defextension` [closes #5]
- Deprecate `require`
- Introduce `import` which imports CDK classes as a var representing the class and an alias representing the Clojure namespace for the class
- `import` creates a class where all instance and static methods for that class are interned - this increases the discoverability of CDK by allowing auto-complete to be leveraged & allows for using common Clojure idioms like threading macros [closes #10]
- Upgrades `clojure.tools.deps` to get rid of logging warnings in some projects [closes #9 #11]
- Fixes warnings about `Runtime` by unmaping that binding for `java.lang.Runtime` [closes #7]

Documentation will follow as a separate PR (the whole Readme needs another pass in light of these changes). In the meantime, this PR: https://github.com/StediInc/node-premier-performance/pull/118 can be used as a reference.