### PR TITLE
Remove deprecated API

### DIFF
--- a/example-app/cdk/stedi/cdk/app/sample.clj
+++ b/example-app/cdk/stedi/cdk/app/sample.clj
@@ -3,17 +3,19 @@
             [stedi.cdk.lambda :as lambda]
             [stedi.app.sample :as sample-app]))
 
-(cdk/import ["@aws-cdk/core" Stack]
+(cdk/import ["@aws-cdk/core" App Stack]
             ["@aws-cdk/aws-apigateway" LambdaRestApi]
             ["@aws-cdk/aws-lambda" Tracing])
 
-(defn AppStack [app id]
-  (let [stack    (Stack app id)
-        function (lambda/fn-from-var stack "function" #'sample-app/handler
-                                     {:tracing Tracing/ACTIVE})]
-    (LambdaRestApi stack "api" {:handler       function
-                                :deployOptions {:tracingEnabled true}})))
+(def app (App {}))
 
-(cdk/defapp app
-  [this]
-  (AppStack this "DevStack"))
+(def stack (Stack app "DevStack"))
+
+(def function
+  (lambda/fn-from-var stack "function" #'sample-app/handler
+                      {:tracing Tracing/ACTIVE}))
+
+(def api
+  (LambdaRestApi stack "api"
+                 {:handler       function
+                  :deployOptions {:tracingEnabled true}}))

--- a/src/stedi/cdk/impl.clj
+++ b/src/stedi/cdk/impl.clj
@@ -1,64 +1,28 @@
 (ns stedi.cdk.impl
-  (:refer-clojure :exclude [require])
-  (:require [clojure.java.browse :as browse]
-            [clojure.string :as string]
+  (:require [clojure.string :as string]
             [clojure.walk :as walk]
             [stedi.cdk.jsii.client :as client])
   (:import (software.amazon.jsii JsiiObjectRef)))
 
-(defn browse-docs [fqn]
-  (let [sanitized (string/replace fqn "/" "_")]
-    (browse/browse-url (format "https://docs.aws.amazon.com/cdk/api/latest/docs/%s.html"
-                               sanitized))))
-
-(defn type-name [fqn]
-  (last (string/split fqn #"\.")))
-
-(defn module-name [fqn]
-  (first (string/split fqn #"\.")))
-
 (declare wrap-objects unwrap-objects)
 
-(defn doc-data [fqn]
-  (-> fqn
-      (module-name)
-      (client/get-manifest)
-      (get-in ["types" fqn])
-      (walk/keywordize-keys)))
-
 (defn invoke-object
-  [cdk-object op & args]
+  [cdk-object op args]
   (assert (keyword? op) "op must be a keyword")
-  (case op
-    :cdk/browse (browse-docs (.getFqn (. cdk-object object-ref)))
-    (-> (client/call-method (. cdk-object object-ref) (name op) (unwrap-objects args))
-        (wrap-objects))))
+  (->> (unwrap-objects args)
+       (client/call-method (. cdk-object object-ref) (name op))
+       (wrap-objects)))
 
 (deftype CDKObject [object-ref]
   clojure.lang.ILookup
   (valAt [_ k]
-    (case k
-      :cdk/definition (doc-data (.getFqn object-ref))
-
-      (-> (client/get-property-value object-ref (name k))
-          (wrap-objects))))
-
-  clojure.lang.IFn
-  (applyTo [this arg-list]
-    (apply invoke-object this arg-list))
-  (invoke [this op]
-    (invoke-object this op))
-  (invoke [this op a]
-    (invoke-object this op a))
-  (invoke [this op a b]
-    (invoke-object this op a b))
-  (invoke [this op a b c]
-    (invoke-object this op a b c))
+    (-> (client/get-property-value object-ref (name k))
+        (wrap-objects)))
 
   java.lang.Object
   (toString [this]
     (try
-      (invoke-object this :toString)
+      (invoke-object this [:toString])
       (catch Exception _
         (.getFqn object-ref)))))
 
@@ -80,69 +44,32 @@
         y))
     x))
 
-(defn create-object [cdk-class overrides args]
-  (let [fqn            (. cdk-class fqn)
-        obj-ref        (atom nil)
-        constructor-fn (fn [& args*]
-                         (if-not @obj-ref
-                           (let [obj (CDKObject. (client/create-object fqn (unwrap-objects args*)))]
-                             (reset! obj-ref obj))
-                           (throw (Exception. "constructor-fn can only be called once"))))]
-    (if-let [build-fn (:cdk/build overrides)]
-      (apply build-fn constructor-fn args)
-      (apply constructor-fn args))
-    (if-let [obj @obj-ref]
-      (when-let [init-fn (:cdk/init overrides)]
-        (apply init-fn obj (rest args)))
-      (throw (Exception. "constructor-fn wasn't called in :cdk/build")))
-    @obj-ref))
+(defn create-object [cdk-class args]
+  (let [fqn (. cdk-class fqn)]
+    (CDKObject. (client/create-object fqn (unwrap-objects args)))))
 
 (defn invoke-class
   [cdk-class op & args]
-  (if (keyword? op)
-    (let [fqs       (. cdk-class fqs)
-          fqn       (. cdk-class fqn)
-          overrides (some-> fqs resolve meta ::overrides)]
-      (case op
-        :cdk/create (create-object cdk-class overrides args)
-        :cdk/browse (browse-docs fqn)
-        :cdk/enum   {"$jsii.enum" (str fqn "/" (name (first args)))}
+  (let [fqn (. cdk-class fqn)]
+    (->> (unwrap-objects args)
+         (client/call-static-method fqn (name op))
+         (wrap-objects))))
 
-        (wrap-objects (client/call-static-method fqn (name op) (unwrap-objects args)))))
-    ;; This isn't ideal and should be dropped when we can drop
-    ;; backwards compatibility with the original syntax
-    (create-object cdk-class {} (concat [op] args))))
-
-(deftype CDKClass [fqn fqs]
+(deftype CDKClass [fqn]
   clojure.lang.ILookup
   (valAt [_ k]
-    (case k
-      :cdk/definition (doc-data fqn)
-
-      (-> (client/get-static-property-value fqn (name k))
-          (wrap-objects))))
+    (-> (client/get-static-property-value fqn (name k))
+        (wrap-objects)))
 
   clojure.lang.IFn
-  (applyTo [this arg-list]
-    (apply invoke-class arg-list))
-  (invoke [this]
-    ;; This isn't ideal and should be dropped when we can drop
-    ;; backwards compatibility with the original syntax
-    (create-object this {} []))
-  (invoke [this op]
-    (invoke-class this op))
-  (invoke [this op a]
-    (invoke-class this op a))
-  (invoke [this op a b]
-    (invoke-class this op a b))
-  (invoke [this op a b c]
-    (invoke-class this op a b c)))
+  (applyTo [this arglist] (create-object this arglist))
+  (invoke [this] (create-object this []))
+  (invoke [this a1] (create-object this [a1]))
+  (invoke [this a1 a2] (create-object this [a1 a2]))
+  (invoke [this a1 a2 a3] (create-object this [a1 a2 a3])))
 
-(defn wrap-class [fqn fqs]
-  (CDKClass. fqn fqs))
-
-(defn make-rest-args-optional [x]
-  (list* (update (into [] x) 1 conj '& '_)))
+(defn wrap-class [fqn]
+  (CDKClass. fqn))
 
 (defn package->ns-sym [package]
   (-> package

--- a/src/stedi/cdk/import.clj
+++ b/src/stedi/cdk/import.clj
@@ -32,14 +32,14 @@
               {:doc      (render-docs docs)
                :arglists (list (mapv (comp symbol :name) parameters))})
             (fn [& args]
-              (let [cdk-class (impl/wrap-class fqn nil)]
+              (let [cdk-class (impl/wrap-class fqn)]
                 (apply impl/invoke-class cdk-class (keyword name) args))))
     (intern ns-sym
             (with-meta (symbol name)
               {:doc      (render-docs docs)
                :arglists (list (vec (cons 'this (mapv (comp symbol :name) parameters))))})
             (fn [this & args]
-              (apply this (keyword name) args)))))
+              (impl/invoke-object this (keyword name) args)))))
 
 (defn- intern-initializer
   [{:keys [ns-sym fqn parameters docs alias*] :as args}]
@@ -51,7 +51,7 @@
              :doc      (with-out-str
                          (println)
                          (clojure.pprint/pprint (manifest fqn)))})
-          (impl/wrap-class fqn nil)))
+          (impl/wrap-class fqn)))
 
 (defn- intern-enum-member
   [{:keys [ns-sym name fqn]}]

--- a/src/stedi/cdk/main.clj
+++ b/src/stedi/cdk/main.clj
@@ -1,7 +1,10 @@
-(ns stedi.cdk.main)
+(ns stedi.cdk.main
+  (:require [stedi.cdk :as cdk]))
+
+(cdk/import ["@aws-cdk/core" App])
 
 (defn -main [& [app-sym]]
-  (let [app (requiring-resolve (symbol app-sym))]
-    (app :synth))
+  (let [app @(requiring-resolve (symbol app-sym))]
+    (App/synth app))
   (shutdown-agents)
   (System/exit 0))


### PR DESCRIPTION
This removes the original (deprecated) `require`-based API for CDK. Maintaining backwards compatibility was causing hard to reason about issues and the original API was not documented and should not be in use except for a few Stedi internal projects.

The core of the issue was the conventional distinction between constructors and static methods:
https://github.com/StediInc/cdk-clj/pull/43/files#diff-a8c46bb6da83b3863f99fbd3fa266650L126-L139

This is now an explicit distinction where the class object can only be invoked as a function. Static methods are interned into an in-memory namespace with the `import` API so that is the only supported mechanism for invoking static methods now.

The `(<class> :cdk/browse)` function is the biggest feature removal and will be replaced by a more explicit function in the `cdk.clj` namespace in a subsequent PR.