### PR TITLE
Account for zero arg methods and improve interned fn error messages

### DIFF
--- a/src/stedi/cdk/import.clj
+++ b/src/stedi/cdk/import.clj
@@ -25,21 +25,36 @@
       (walk/keywordize-keys)))
 
 (defn- intern-method
-  [{:keys [static parameters docs name ns-sym fqn]}]
+  [{:keys [static parameters docs name ns-sym fqn] :as intern-args}]
   (if static
     (intern ns-sym
             (with-meta (symbol name)
               {:doc      (render-docs docs)
                :arglists (list (mapv (comp symbol :name) parameters))})
             (fn [& args]
-              (let [cdk-class (impl/wrap-class fqn)]
-                (apply impl/invoke-class cdk-class (keyword name) args))))
+              (try
+                (let [cdk-class (impl/wrap-class fqn)]
+                  (apply impl/invoke-class cdk-class (keyword name) (or args [])))
+                (catch Exception e
+                  (throw (ex-info "static-method-call-failed"
+                                  {:class       fqn
+                                   :method-name name
+                                   :args        args
+                                   :intern-args intern-args} e))))))
     (intern ns-sym
             (with-meta (symbol name)
               {:doc      (render-docs docs)
                :arglists (list (vec (cons 'this (mapv (comp symbol :name) parameters))))})
             (fn [this & args]
-              (impl/invoke-object this (keyword name) args)))))
+              (try
+                (impl/invoke-object this (keyword name) (or args []))
+                (catch Exception e
+                  (throw (ex-info "instance-method-call-failed"
+                                  {:class       fqn
+                                   :instance    this
+                                   :method-name name
+                                   :args        args
+                                   :intern-args intern-args} e))))))))
 
 (defn- intern-initializer
   [{:keys [fqn parameters alias*]}]


### PR DESCRIPTION
This commit accounts for methods which require zero args by
defaulting to an empty vector when no arguments are
provided. Previously a nil would be passed, which would cause some
versions of jackson-databind to throw a class cast exception. Other
version of jackson-databind seem to handle the nil case for
us. Regardless we want this to be as reliable as possible, so we now
check for nil and pass an empty vector in this case. If there is an
exception that occurs when calling these interned functions, it will now
be propagated with all of the information needed to debug the issue.