### PR TITLE
Report unresolved modules.

### DIFF
--- a/src/stedi/cdk/jsii/client.clj
+++ b/src/stedi/cdk/jsii/client.clj
@@ -23,6 +23,8 @@
 
 (defn load-module [module-name]
   (let [module-name* (first (clojure.string/split module-name #"\."))
+        _            (assert (modules/exists? module-name*)
+                             (format "Unable to resolve CDK module: %s" module-name*))
         to-load      (modules/dependencies-for module-name*)]
     (doseq [{:keys [manifest module]} to-load]
       (when-not (@loaded-modules manifest)

--- a/src/stedi/cdk/jsii/modules.clj
+++ b/src/stedi/cdk/jsii/modules.clj
@@ -65,6 +65,10 @@
 
 (def ^:private fetch-all-modules (memoize fetch-all-modules*))
 
+(defn exists?
+  [module-name]
+  (boolean (get (fetch-all-modules) module-name)))
+
 (defn dependencies-for
   [module-name]
   (let [all-modules     (fetch-all-modules)


### PR DESCRIPTION
With CDK modules no longer being bundled with cdk-clj, it is important to give
users the information needed to resolve module resolution failures, rather than
raising unhelpful NPEs; instead of:

```
1. Caused by java.lang.NullPointerException
   (No message)

           JsiiClient.java:   48  software.amazon.jsii.JsiiClient/loadModule
                       nil:   -1  sun.reflect.GeneratedMethodAccessor13/invoke
DelegatingMethodAccessorImpl.java:   43  sun.reflect.DelegatingMethodAccessorImpl/invoke
               Method.java:  498  java.lang.reflect.Method/invoke
            Reflector.java:  167  clojure.lang.Reflector/invokeMatchingMethod
            Reflector.java:  102  clojure.lang.Reflector/invokeInstanceMethod
                client.clj:   29  stedi.cdk.jsii.client/load-module
```

the following is now raised:

```
1. Caused by java.lang.AssertionError
   Assert failed: Unable to resolve CDK module: @aws-cdk/foo (modules/exists?
   module-name*)
```