### PR TITLE
Spec fixes

### DIFF
--- a/src/stedi/jsii/assembly.clj
+++ b/src/stedi/jsii/assembly.clj
@@ -74,7 +74,10 @@
                  (merge-types (expand-type types base) t)
                  t)
 
-        interfaces (map #(get types %) (:interfaces t))]
+        interfaces (map (fn [interface-fqn]
+                          (let [interface-t (get types interface-fqn)]
+                            (expand-type types interface-t)))
+                        (:interfaces t))]
     (reduce #(merge-types %2 %1) merged interfaces)))
 
 (defn- indexed-types

--- a/src/stedi/jsii/impl.clj
+++ b/src/stedi/jsii/impl.clj
@@ -181,18 +181,21 @@
 
 (defn class-instance?
   [fqn x]
-  (and (instance? JsiiObject x)
-       (some #{fqn} (base-classes x))))
+  (boolean
+    (and (instance? JsiiObject x)
+         (some #{fqn} (base-classes x)))))
 
 (defn enum-member?
   [fqn x]
-  (and (instance? JsiiEnumMember x)
-       (= fqn (.-fqn x))
-       ((member-values fqn) (.-value x))))
+  (boolean
+    (and (instance? JsiiEnumMember x)
+         (= fqn (.-fqn x))
+         ((member-values fqn) (.-value x)))))
 
 (defn satisfies-interface?
   [fqn x]
-  (and (instance? JsiiObject x)
-       (or (= (.-fqn x) fqn)
-           (let [{:keys [interfaces]} (get-type-info x)]
-             (some #{fqn} interfaces)))))
+  (boolean
+    (and (instance? JsiiObject x)
+         (or (= (.-fqn x) fqn)
+             (let [{:keys [interfaces]} (get-type-info x)]
+               (some #{fqn} interfaces))))))

--- a/src/stedi/jsii/spec.clj
+++ b/src/stedi/jsii/spec.clj
@@ -118,11 +118,13 @@
                     parameters)))
 
 (defn- method-arg-spec-form
-  [{:keys [fqn]} {:keys [static parameters]}]
+  [{:keys [fqn]} {:keys [static parameters overrides]}]
   (let [arities* (assm/arities
                    (concat (when-not static
                              (list {:name "this"
-                                    :type {:fqn fqn}}))
+                                    :type (if overrides
+                                            {:fqn overrides}
+                                            {:fqn fqn})}))
                            parameters))]
     (if (= 1 (count arities*))
       (method-arity-form (first arities*))


### PR DESCRIPTION
Fixes a few spec-checking related problems:
- interfaces were not being expanded preventing extended interfaces from being picked up by classes during spec checking
- classes extending interfaces weren't using the correct spec for `this` (should be the fqn for the interface)