### PR TITLE
Allow aliasing with `:as` to rename imports

### DIFF
--- a/test/stedi/cdk_test.clj
+++ b/test/stedi/cdk_test.clj
@@ -3,10 +3,8 @@
   (:require [clojure.test :refer [deftest is testing]]
             [stedi.cdk :as cdk]))
 
-(cdk/import ["@aws-cdk/core"
-             Stack
-             App :as A]
-            ["@aws-cdk/aws-lambda" Runtime])
+(cdk/import [[App :as A, Stack] :from "@aws-cdk/core"]
+            [[Runtime] :from "@aws-cdk/aws-lambda"])
 
 (deftest cdk-example-test
   (testing "instantiating an object"

--- a/test/stedi/cdk_test.clj
+++ b/test/stedi/cdk_test.clj
@@ -3,7 +3,9 @@
   (:require [clojure.test :refer [deftest is testing]]
             [stedi.cdk :as cdk]))
 
-(cdk/import ["@aws-cdk/core" Stack]
+(cdk/import ["@aws-cdk/core"
+             Stack
+             App :as A]
             ["@aws-cdk/aws-lambda" Runtime])
 
 (deftest cdk-example-test
@@ -16,4 +18,6 @@
   (testing "calling a static method"
     (is (Stack/isStack (Stack nil "my-stack"))))
   (testing "getting a static property of a class"
-    (is (:JAVA_8 Runtime))))
+    (is (:JAVA_8 Runtime)))
+  (testing "renaming an alias"
+    (is (A/isApp (A)))))


### PR DESCRIPTION
There are classes with conflicting names in CDK. For example
`@aws-cdk/core.CfnParameter` and `@aws-cdk/aws-ssm.CfnParameter`. This
causes a conflict that is currently unresolvable.

This change adds the ability to change the name of an import with an
`:as` flag.

Example:

``` clojure
(import ["@aws-cdk/aws-ssm"
         CfnParameter :as CfnSsmParameter])
```

This would alias the `@aws-cdk/aws-ssm.CfnParameter` namespace and
refer the `@aws-cdk/aws-ssm.CfnParameter` class to the symbol
`CfnSsmParameter` in the current namespace.