### PR TITLE
Browse without any arguments should go to the docs root

### DIFF
--- a/src/stedi/cdk.clj
+++ b/src/stedi/cdk.clj
@@ -7,7 +7,7 @@
             [stedi.jsii :as jsii]))
 
 (def ^:private docs-prefix
-  "https://docs.aws.amazon.com/cdk/api/latest/docs")
+  "https://docs.aws.amazon.com/cdk/api/latest")
 
 (defn browse
   "Browse to CDK documentation by CDK fqn, CDK object or CDK
@@ -26,8 +26,7 @@
   (cdk/browse Stack)   ;; can open docs from a class
   (cdk/browse (Stack)) ;; can also open docs from an instance
   "
-  ([] (browse/browse-url
-        (str docs-prefix "/aws-construct-library.html")))
+  ([] (browse/browse-url docs-prefix))
   ([obj-class-or-fqn]
    (letfn [(cdk-class? [fqn]
              (re-find #"\.[A-Za-z]+$" fqn))
@@ -38,7 +37,7 @@
                      (string/replace fqn "/" "_")
                      (str (string/replace fqn "@aws-cdk/" "")
                           "-readme"))]
-               (format "%s/%s.html" docs-prefix url-formatted-fqn)))]
+               (format "%s/docs/%s.html" docs-prefix url-formatted-fqn)))]
      (browse/browse-url
        (cond
          (string? obj-class-or-fqn)


### PR DESCRIPTION
Right now browse points to the [API Reference][1], however, this does
not have an easily accessible link to the [Developer Guide][2] which
provides valuable background context for CDK.

The documentation [root][3] has links to both the Developer Guide and
the API Reference which makes it a much better starting point for
`(cdk/browse)`.

[1]:https://docs.aws.amazon.com/cdk/api/latest/docs/aws-construct-library.html
[2]:https://docs.aws.amazon.com/cdk/latest/guide/home.html
[3]:https://docs.aws.amazon.com/cdk/api/latest/