### PR TITLE
Add basics example and scaffolding for larger example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .nrepl-port
 target
 /.clj-kondo
+**/cdk.out
+**/classes

--- a/examples/basics/cdk.json
+++ b/examples/basics/cdk.json
@@ -1,0 +1,1 @@
+{"app":"clojure -A:dev -m stedi.cdk.main stedi.basics.cdk/app"}

--- a/examples/basics/cdk/stedi/basics/cdk.clj
+++ b/examples/basics/cdk/stedi/basics/cdk.clj
@@ -81,7 +81,8 @@ App/synth
 ;; and functions:
 
 (comment
-  (Bucket stack nil) ;; Fails with spec error
+  (Bucket stack nil)
+  ;; Fails with spec error
   )
 
 (def bucket (Bucket stack "bucket"))
@@ -111,6 +112,10 @@ App/synth
     (compile 'stedi.lambada)
     (uberdeps/package deps jarpath {:aliases [:classes]})))
 
+(comment
+  (cdk/browse Function)
+  )
+
 (def my-fn
   (Function stack
             "my-fn"
@@ -118,7 +123,13 @@ App/synth
              :handler     "stedi.cdk.basics.Hello"
              :runtime     (:JAVA_8 Runtime)               ;; Getting a static property
              :environment {"BUCKET" (:bucketName bucket)} ;; Getting an instance property
-             })) 
+             }))
+
+(comment
+  ;; See it bound to the construct tree
+  (map (comp :path :node)
+       (get-in stack [:node :children]))
+  )
 
 ;; We can grant the function write access to the bucket using an
 ;; instance method

--- a/examples/basics/cdk/stedi/basics/cdk.clj
+++ b/examples/basics/cdk/stedi/basics/cdk.clj
@@ -1,0 +1,141 @@
+(ns stedi.basics.cdk
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [stedi.cdk :as cdk]
+            [uberdeps.api :as uberdeps]))
+
+;; CDK is a framework released by Amazon that allows developers to
+;; deploy CloudFormation-based infrastructure using their prefered
+;; language.
+
+;; It is built from TypeScript and made available to other languages
+;; through the JSii protocol by Amazon. JSii allows other languages to
+;; interact with JavaScript classes through an RPC protocol.
+
+;; cdk-clj wraps the JSii protocol for CDK classes in Clojure.
+
+;; The best way of getting information about what is availble via CDK
+;; is to call `(cdk/browse)` in the REPL. This will take you to the
+;; AWS CDK API reference documentation.
+
+(comment
+  (cdk/browse)
+  )
+
+;; CDK applications consist of Constructs arranged into a tree
+;; structure. Constructs represent one or more AWS resources. All CDK
+;; applications have an App construct at the root of the
+;; tree. `cdk-clj` exposes access to these constructs through the
+;; `cdk/import` macro.
+
+(cdk/import ["@aws-cdk/core" App])
+
+;; Import does two things:
+;; 1. makes App resolvable to a jsii-class in the local namespace
+;; 2. aliases the ns for "@aws-cdk/core.App" to App
+
+;; App will now resolve to a jsii-class
+App
+
+;; Invoking the class calls its constructor and returns a
+;; jsii-instance:
+(def app (App))
+
+;; These constructor vars also have docstrings
+App
+
+;; Import also makes an alias to the ns that contains all the static
+;; and instance methods for App
+App/isApp
+App/synth
+
+;; You can also browse to a constructs documentation via browse on
+;; the constructor or an instance:
+
+(comment
+  (cdk/browse app)
+  (cdk/browse App)
+  )
+
+;; Applications are composed of one or more Stacks, each representing
+;; a CloudFormation Stack. A Stack is a Construct as well.
+
+(cdk/import ["@aws-cdk/core" Stack])
+
+;; Child constructs are connected to their parent by passing in the
+;; parent as the scope of the child's constructor function.
+
+(def stack (Stack app "cdk-clj-basics"))
+
+;; Class instances implement the ILookup interface so they work with
+;; keyword lookups
+
+(:stackName stack)
+
+;; A stack needs at least one resource Construct in order to be
+;; deployable so lets add a bucket.
+
+(cdk/import ["@aws-cdk/aws-s3" Bucket])
+
+;; cdk-clj generates specs for and instruments all jsii constructors
+;; and functions:
+
+(comment
+  (Bucket stack nil) ;; Fails with spec error
+  )
+
+(def bucket (Bucket stack "bucket"))
+
+;; Buckets aren't particularly interesting, and lambdas + serverless
+;; are all the rage so lets add a lambda function as well.
+
+(cdk/import ["@aws-cdk/aws-lambda" Code Function Runtime])
+
+(defn- clean
+  []
+  (->> (io/file "classes")
+       (file-seq)
+       (reverse)
+       (map io/delete-file)
+       (dorun)))
+
+(def jarpath "target/app.jar")
+
+;; Build an uberjar with the compiled source + dependency classes
+
+(let [deps (edn/read-string (slurp "deps.edn"))]
+  (when (.exists (io/file "classes")) (clean))
+  (with-out-str
+    (io/make-parents "classes/.")
+    (io/make-parents jarpath)
+    (compile 'stedi.lambada)
+    (uberdeps/package deps jarpath {:aliases [:classes]})))
+
+(def my-fn
+  (Function stack
+            "my-fn"
+            {:code        (Code/fromAsset jarpath)        ;; Calling a static method
+             :handler     "stedi.cdk.basics.Hello"
+             :runtime     (:JAVA_8 Runtime)               ;; Getting a static property
+             :environment {"BUCKET" (:bucketName bucket)} ;; Getting an instance property
+             })) 
+
+;; We can grant the function write access to the bucket using an
+;; instance method
+
+(Bucket/grantWrite bucket my-fn)
+
+;; CDK constructs often have functions for granting permissions,
+;; adding metrics and triggering events.
+
+;; This app can now be deployed using `cdk-cli` in a shell with AWS
+;; credentials configured.
+
+;; Synth:
+;; cdk synth
+
+;; Deploy:
+;; cdk deploy
+
+;; Destroy:
+;; cdk destroy

--- a/examples/basics/deps.edn
+++ b/examples/basics/deps.edn
@@ -1,0 +1,7 @@
+{:paths   ["src"]
+ :deps    {org.clojure/clojure {:mvn/version "1.10.1"}
+           uswitch/lambada     {:mvn/version "0.1.2"}}
+ :aliases {:classes {:extra-paths ["classes"]}
+           :dev     {:extra-paths ["cdk"]
+                     :extra-deps  {stedi/cdk-clj {:local/root "../../"}
+                                   uberdeps      {:mvn/version "0.1.6"}}}}}

--- a/examples/basics/src/stedi/lambada.clj
+++ b/examples/basics/src/stedi/lambada.clj
@@ -1,0 +1,7 @@
+(ns stedi.lambada
+  (:require [uswitch.lambada.core :refer [deflambdafn]]))
+
+(deflambdafn stedi.cdk.basics.Hello
+  [in out ctx]
+  (let [bucket-name (System/getenv "BUCKET")]
+    (.write out (.getBytes (format "Hello! Bucket Name: %s" bucket-name)))))

--- a/examples/depswatch/cdk.json
+++ b/examples/depswatch/cdk.json
@@ -1,0 +1,1 @@
+{"app":"clojure -A:dev -m stedi.cdk.main depswatch.cdk/app"}

--- a/examples/depswatch/cdk/depswatch/cdk.clj
+++ b/examples/depswatch/cdk/depswatch/cdk.clj
@@ -38,7 +38,7 @@
              StartExecution])
 
 (defn- clean
-  [path]
+  []
   (->> (io/file "classes")
        (file-seq)
        (reverse)
@@ -48,11 +48,12 @@
 (def code
   (let [jarpath "target/app.jar"
         deps    (edn/read-string (slurp "deps.edn"))]
-    (clean "classes")
-    (io/make-parents "classes/.")
-    (io/make-parents jarpath)
-    (compile 'depswatch.lambada)
-    (uberdeps/package deps jarpath {:aliases [:classes]})
+    (with-out-str
+      (clean)
+      (io/make-parents "classes/.")
+      (io/make-parents jarpath)
+      (compile 'depswatch.lambada)
+      (uberdeps/package deps jarpath {:aliases [:classes]}))
     (Code/fromAsset jarpath)))
 
 (defn LambadaFunction

--- a/examples/depswatch/cdk/depswatch/cdk.clj
+++ b/examples/depswatch/cdk/depswatch/cdk.clj
@@ -1,0 +1,151 @@
+(ns depswatch.cdk
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [stedi.cdk :as cdk]
+            [uberdeps.api :as uberdeps]))
+
+(cdk/import ["@aws-cdk/core"
+             App
+             Construct
+             Duration
+             Stack]
+            ["@aws-cdk/aws-apigateway"
+             LambdaRestApi]
+            ["@aws-cdk/aws-dynamodb"
+             AttributeType
+             Table]
+            ["@aws-cdk/aws-events"
+             Rule
+             Schedule]
+            ["@aws-cdk/aws-events-targets"
+             SfnStateMachine]
+            ["@aws-cdk/aws-lambda"
+             Code
+             Function
+             Runtime
+             Tracing]
+            ["@aws-cdk/aws-stepfunctions"
+             Chain
+             Choice
+             Condition
+             Data
+             Map
+             StateMachine
+             Succeed
+             Task]
+            ["@aws-cdk/aws-stepfunctions-tasks"
+             InvokeFunction
+             StartExecution])
+
+(defn- clean
+  [path]
+  (->> (io/file "classes")
+       (file-seq)
+       (reverse)
+       (map io/delete-file)
+       (dorun)))
+
+(def code
+  (let [jarpath "target/app.jar"
+        deps    (edn/read-string (slurp "deps.edn"))]
+    (clean "classes")
+    (io/make-parents "classes/.")
+    (io/make-parents jarpath)
+    (compile 'depswatch.lambada)
+    (uberdeps/package deps jarpath {:aliases [:classes]})
+    (Code/fromAsset jarpath)))
+
+(defn LambadaFunction
+  [scope id props]
+  (Function scope
+            id
+            (merge {:code       code
+                    :memorySize 2048
+                    :runtime    (:JAVA_8 Runtime)
+                    :tracing    Tracing/ACTIVE}
+                   props)))
+
+(defn TaskFunction
+  [scope id {:keys [handler resultPath]}]
+  (let [construct (Construct scope id)
+        fn        (LambadaFunction construct "fn" {:handler handler})
+        task      (Task construct
+                        id
+                        {:task       (InvokeFunction fn)
+                         :resultPath (or resultPath "$")})]
+    task))
+
+(defn RunJobStateMachine
+  [scope id]
+  (let [construct (Construct scope id)
+        definition
+        (-> (Chain/start
+              (TaskFunction construct
+                            "get-deps-edn"
+                            {:handler    "depswatch.GetDepsEdn"
+                             :resultPath "$.depsEdn"}))
+            (Chain/next
+              (TaskFunction construct
+                            "check-newer"
+                            {:handler    "depswatch.CheckNewer"
+                             :resultPath "$.newer"}))
+            (Chain/next
+              (TaskFunction construct
+                            "check-sent"
+                            {:handler    "depswatch.CheckSent"
+                             :resultPath "$.sent"}))
+            (Chain/next
+              (doto (Choice construct "was-sent")
+                (Choice/when (Condition/booleanEquals "$.sent" true)
+                  (Succeed construct "already-sent"))
+
+                (Choice/when (Condition/booleanEquals "$.sent" false)
+                  (TaskFunction construct
+                                "notify-slack"
+                                {:handler "depswatch.NotifySlack"})))))]
+    (StateMachine construct "sfn" {:definition definition})))
+
+(defn StartJobsStateMachine
+  [scope id {:keys [run-job]}]
+  (let [construct (Construct scope id)
+        task      (StartExecution run-job
+                                  {:input {:owner (Data/stringAt "$.owner")
+                                           :repo  (Data/stringAt "$.repo")}})
+        definition
+        (doto (TaskFunction construct
+                            "get-repos"
+                            {:handler "depswatch.GetRepos"})
+          (Task/next
+            (doto (Map construct "run-jobs")
+              (Map/iterator
+                (Task construct "run-job" {:task task})))))]
+    (StateMachine construct "sfn" {:definition definition})))
+
+(defn AppStack
+  [scope id {:keys [timer?]}]
+  (let [stack         (Stack scope id)
+        watched-repos (Table stack
+                             "watched-repos"
+                             {:partitionKey {:name "owner"
+                                             :type AttributeType/STRING}})
+        slack-hook    (LambadaFunction stack
+                                       "slack-hook"
+                                       {:handler "depswatch.SlackHook"
+                                        :environment
+                                        {"WATCHED_REPOS" (:tableName watched-repos)}})
+        run-job       (RunJobStateMachine stack "run-job")
+        start-jobs    (StartJobsStateMachine stack "start-jobs" {:run-job run-job})]
+    (when timer?
+      (Rule stack
+            "timer"
+            {:schedule (Schedule/rate
+                         (Duration/minutes 1))
+             :targets  [(SfnStateMachine start-jobs)]}))
+    (Table/grantReadWriteData watched-repos slack-hook)
+    (LambdaRestApi slack-hook "api" {:handler slack-hook})
+    stack))
+
+(def app (App))
+
+(AppStack app "depswatch-dev" {:timer? false})
+(AppStack app "depswatch-prod" {:timer? true})

--- a/examples/depswatch/deps.edn
+++ b/examples/depswatch/deps.edn
@@ -1,0 +1,19 @@
+{:paths ["src"]
+ :deps  {org.clojure/clojure {:mvn/version "1.10.1"}
+
+         org.clojure/data.json {:mvn/version "0.2.6"}
+         uswitch/lambada       {:mvn/version "0.1.2"}}
+ :aliases {:classes {:extra-paths ["classes"]}
+           :dev     {:extra-paths ["cdk"]
+                     :extra-deps  {stediinc/cdk-clj {:git/url "https://github.com/stediinc/cdk-clj.git"
+                                                     :sha     "fc982c9412b848ca78be37b8eaaf80ff455ada54"}
+
+                                   uberdeps {:mvn/version "0.1.6"}
+
+                                   software.amazon.awscdk/apigateway          {:mvn/version "1.15.0.DEVPREVIEW"}
+                                   software.amazon.awscdk/dynamodb            {:mvn/version "1.15.0.DEVPREVIEW"}
+                                   software.amazon.awscdk/events              {:mvn/version "1.15.0.DEVPREVIEW"}
+                                   software.amazon.awscdk/events-targets      {:mvn/version "1.15.0.DEVPREVIEW"}
+                                   software.amazon.awscdk/lambda              {:mvn/version "1.15.0.DEVPREVIEW"}
+                                   software.amazon.awscdk/stepfunctions       {:mvn/version "1.15.0.DEVPREVIEW"}
+                                   software.amazon.awscdk/stepfunctions-tasks {:mvn/version "1.15.0.DEVPREVIEW"}}}}}

--- a/examples/depswatch/src/depswatch/lambada.clj
+++ b/examples/depswatch/src/depswatch/lambada.clj
@@ -1,0 +1,42 @@
+(ns depswatch.lambada
+  (:require [clojure.data.json :as json]
+            [uswitch.lambada.core :refer [deflambdafn]]))
+
+(deflambdafn depswatch.GetRepos
+  [in out ctx]
+  (.write out
+          (.getBytes
+            (json/write-str
+              [{:owner "stediinc"
+                :repo  "cdk-clj"}]))))
+
+(deflambdafn depswatch.GetDepsEdn
+  [in out ctx]
+  (.write out
+          (.getBytes
+            (json/write-str
+              (pr-str
+                {:deps {'midje {:mvn/version "1.9.8"}}})))))
+
+(deflambdafn depswatch.CheckNewer
+  [in out ctx]
+  (.write out
+          (.getBytes
+            (json/write-str
+              (pr-str
+                {'midje {:old-version "1.9.8"
+                         :new-version "1.9.9"}})))))
+
+(deflambdafn depswatch.CheckSent
+  [in out ctx]
+  (.write out
+          (.getBytes
+            (json/write-str
+              false))))
+
+(deflambdafn depswatch.NotifySlack
+  [in out ctx]
+  (.write out
+          (.getBytes
+            (json/write-str
+              "Slack notified"))))


### PR DESCRIPTION
This adds a working basics example for deploying a lambda and a bucket. It also starts a more substantial slack bot example which is deployable but not yet functional.

Both of these examples are to be featured in the cdk-clj talk at conj.