### PR TITLE
Don't partial impl predicates in specs

### DIFF
--- a/src/stedi/jsii/spec.clj
+++ b/src/stedi/jsii/spec.clj
@@ -65,7 +65,7 @@
 (defn- class-spec-definition
   [{:keys [fqn]}]
   `(s/def ~(fqn/fqn->qualified-keyword fqn)
-     (s/spec (partial impl/class-instance? ~fqn)
+     (s/spec #(impl/class-instance? ~fqn %)
              :gen (partial gen-class-instance ~fqn))))
 
 (defn gen-enum-member
@@ -79,7 +79,7 @@
 (defn- enum-spec-definition
   [{:keys [fqn]}]
   `(s/def ~(fqn/fqn->qualified-keyword fqn)
-     (s/spec (partial impl/enum-member? ~fqn)
+     (s/spec #(impl/enum-member? ~fqn %)
              :gen (partial gen-enum-member ~fqn))))
 
 (defn gen-satisfies-interface
@@ -90,7 +90,7 @@
 (defn- interface-spec-definition
   [{:keys [fqn]}]
   `(s/def ~(fqn/fqn->qualified-keyword fqn)
-     (s/spec (partial impl/satisfies-interface? ~fqn)
+     (s/spec #(impl/satisfies-interface? ~fqn %)
              :gen (partial gen-satisfies-interface ~fqn))))
 
 (defn- datatype-spec-definition


### PR DESCRIPTION
The predicates in the impl namespace check for instances of the types
definied in that namespace and the spec namespace caches the spec
definitions as they are loaded lazily. When partial was used, this
caused the currently defined type to be used for `instance?` checks
which would be replaced by a new type when `deftype` was re-evaluated
in impl. This would cause all of the cached specs to break since the
type they were checking is no longer the type being created. This
change removes this behavior by removing `partial` and forcing the
predicates to be resolved as they are used rather than being cached
when they are generated.