### PR TITLE
Fix jsii runtime upgrade issue and improve assembly interface

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,7 @@
  :deps    {com.stuartsierra/dependency         {:mvn/version "0.2.0"}
            org.apache.commons/commons-compress {:mvn/version "1.19"}
            org.clojure/data.json               {:mvn/version "0.2.6"}
-           software.amazon.jsii/jsii-runtime   {:mvn/version "0.19.0"}
+           software.amazon.jsii/jsii-runtime   {:mvn/version "0.20.4"}
            software.amazon.awscdk/core         {:mvn/version "1.12.0.DEVPREVIEW"
                                                 :exclude     [software.amazon.jsii/jsii-runtime]}
            software.amazon.awscdk/lambda       {:mvn/version "1.12.0.DEVPREVIEW"

--- a/src/stedi/jsii/client.clj
+++ b/src/stedi/jsii/client.clj
@@ -53,7 +53,8 @@
   ([fqn initializer-args]
    (load-module fqn)
    (-> (.createObject (client) fqn (map edn->json-node initializer-args))
-       (.getObjId))))
+       (.toJson)
+       (json-node->edn))))
 
 (defn delete-object
   [object-ref]

--- a/src/stedi/jsii/import.clj
+++ b/src/stedi/jsii/import.clj
@@ -101,7 +101,8 @@
         impl-ns-sym   (symbol (str target-ns-sym ".impl"))
         c             (impl/get-class fqn)
 
-        {:keys [methods members]} (impl/get-type-info c)]
+        {:keys [members]} (impl/get-type-info c)
+        methods           (assm/methods fqn)]
     (create-ns target-ns-sym)
     (create-ns impl-ns-sym)
     (ns-unmap impl-ns-sym class-sym)

--- a/src/stedi/jsii/spec.clj
+++ b/src/stedi/jsii/spec.clj
@@ -60,7 +60,7 @@
 
 (defn gen-class-instance
   [fqn]
-  (sgen/return (impl/->JsiiObject fqn nil)))
+  (sgen/return (impl/->JsiiObject fqn [] nil)))
 
 (defn- class-spec-definition
   [{:keys [fqn]}]
@@ -85,7 +85,8 @@
 (defn gen-satisfies-interface
   [fqn]
   (sgen/return
-    (impl/->JsiiObject fqn nil)))
+    ;; TODO: fqn for object-id is no longer a correct assumption
+    (impl/->JsiiObject fqn [fqn] nil)))
 
 (defn- interface-spec-definition
   [{:keys [fqn]}]
@@ -161,7 +162,10 @@
 (defn spec-definitions
   [t]
   (try
-    (let [{:keys [initializer methods properties]} t
+    (let [{:keys [initializer]} t
+
+          methods    (some-> t (:fqn) (assm/methods))
+          properties (some-> t (:fqn) (assm/properties))
 
           type-definition
           (case (metatype t)

--- a/test/stedi/cdk_test.clj
+++ b/test/stedi/cdk_test.clj
@@ -4,7 +4,8 @@
             [stedi.cdk :as cdk]))
 
 (cdk/import [[App :as A, Stack] :from "@aws-cdk/core"]
-            [[Runtime] :from "@aws-cdk/aws-lambda"])
+            [[Function Runtime] :from "@aws-cdk/aws-lambda"]
+            [[StringParameter] :from "@aws-cdk/aws-ssm"])
 
 (deftest cdk-example-test
   (testing "instantiating an object"
@@ -18,4 +19,9 @@
   (testing "getting a static property of a class"
     (is (:JAVA_8 Runtime)))
   (testing "renaming an alias"
-    (is (A/isApp (A)))))
+    (is (A/isApp (A))))
+  (testing "calling a method on a returned interface"
+    (let [s (Stack)]
+      (is (StringParameter/grantRead
+            (StringParameter/fromStringParameterName s "param" "param-name")
+            (Function/fromFunctionArn s "fn" "function-arn"))))))

--- a/test/stedi/jsii_test.clj
+++ b/test/stedi/jsii_test.clj
@@ -51,9 +51,6 @@
       (is (= '#{aws-cdk.core.App/synth
                 aws-cdk.core.App/isApp
                 aws-cdk.core.App/isConstruct
-                aws-cdk.core.App/synthesize
-                aws-cdk.core.App/validate
-                aws-cdk.core.App/prepare
                 aws-cdk.core.App/toString}
              interned-symbols))))
 


### PR DESCRIPTION
jsii changed the spec of interfaces with the upgrade to 0.20.x. Prior
to the upgrade, jsii returned references to an interface named with
the protocol name in the reference (e.g. `{"$jsii.byref":
"@aws-cdk/aws-ssm.IParameter@10001"}`). After the change, jsii returns
a non-interface class as the object reference and a list of interfaces
the instance implements.

This broke our specs since the we weren't looking for the interfaces
key and the returned object reference no longer implemented the
required interface (since that infromation is now contained in the
interfaces key).

This change fixes this issue while remaining backwards compatibility
with previous jsii runtimes by conditionally looking for the
interfaces key and using the results to check the satisfaction of the
interface when the key is present.

To clean up the implementation, the assembly namespace no longer tries
to expand type information by merging interfaces and base classes in
its object heirarchy. Instead, it presents an interface to retrieve
`methods`, `properties`, `interfaces` and the `class-heirarchy`. These
functions take into account any base classes and interfaces that need
to be accounted for rather than doing the rollup ahead of time.

In working through this issue a few other issues were identified and
fixed:
- static properties are now only rendered on the JsiiClass printer
- instance properties are now only rendered on the JsiiObject printer
- protected properties are no longer printed
- protected methods are no longer interned