### PR TITLE
Jsii concerns should be separated from cdk concerns

### DIFF
--- a/src/stedi/cdk/alpha.clj
+++ b/src/stedi/cdk/alpha.clj
@@ -5,7 +5,7 @@
             [clojure.java.io :as io]
             [clojure.spec.alpha :as s]
             [clojure.string :as string]
-            [stedi.cdk.alpha.jsii :as jsii]))
+            [stedi.jsii.alpha :as jsii]))
 
 (def ^:private docs-prefix
   "https://docs.aws.amazon.com/cdk/api/latest")

--- a/src/stedi/jsii/alpha.clj
+++ b/src/stedi/jsii/alpha.clj
@@ -1,8 +1,8 @@
-(ns stedi.cdk.alpha.jsii
+(ns stedi.jsii.alpha
   "A Clojure-based interface into jsii modules."
-  (:require [stedi.cdk.alpha.jsii.client :as client]
-            [stedi.cdk.alpha.jsii.impl :as impl]
-            [stedi.cdk.alpha.jsii.import :as import]))
+  (:require [stedi.jsii.alpha.client :as client]
+            [stedi.jsii.alpha.impl :as impl]
+            [stedi.jsii.alpha.import :as import]))
 
 (defn get-class
   "Gets the jsii class for a given fqn."
@@ -14,10 +14,10 @@
   [x]
   (boolean
     (some #(instance? % x)
-          [stedi.cdk.alpha.jsii.impl.JsiiObject
-           stedi.cdk.alpha.jsii.impl.JsiiClass
-           stedi.cdk.alpha.jsii.impl.JsiiEnumClass
-           stedi.cdk.alpha.jsii.impl.JsiiEnumMember])))
+          [stedi.jsii.alpha.impl.JsiiObject
+           stedi.jsii.alpha.impl.JsiiClass
+           stedi.jsii.alpha.impl.JsiiEnumClass
+           stedi.jsii.alpha.impl.JsiiEnumMember])))
 
 (defn fqn
   "Returns the fqn of a jsii primitive."

--- a/src/stedi/jsii/alpha/assembly.clj
+++ b/src/stedi/jsii/alpha/assembly.clj
@@ -1,4 +1,4 @@
-(ns stedi.cdk.alpha.jsii.assembly
+(ns stedi.jsii.alpha.assembly
   (:require [clojure.data.json :as json]
             [clojure.java.io :as io]
             [clojure.string :as string])
@@ -110,7 +110,9 @@
 (defn- properties*
   [fqn]
   (when-let [t (get-type fqn)]
-    (lazy-cat (when-let [base (:base t)]
+    (lazy-cat (when-let [interfaces (:interfaces t)]
+                (mapcat properties* interfaces))
+              (when-let [base (:base t)]
                 (properties* base))
               (:properties t))))
 

--- a/src/stedi/jsii/alpha/client.clj
+++ b/src/stedi/jsii/alpha/client.clj
@@ -1,7 +1,7 @@
-(ns stedi.cdk.alpha.jsii.client
+(ns stedi.jsii.alpha.client
   (:require [clojure.data.json :as json]
             [clojure.string :as string]
-            [stedi.cdk.alpha.jsii.assembly :as assm])
+            [stedi.jsii.alpha.assembly :as assm])
   (:import (com.fasterxml.jackson.databind ObjectMapper)
            (software.amazon.jsii JsiiRuntime JsiiModule JsiiObjectRef)))
 

--- a/src/stedi/jsii/alpha/fqn.clj
+++ b/src/stedi/jsii/alpha/fqn.clj
@@ -1,4 +1,4 @@
-(ns stedi.cdk.alpha.jsii.fqn
+(ns stedi.jsii.alpha.fqn
   (:require [clojure.string :as string]))
 
 (defn- tokenize

--- a/src/stedi/jsii/alpha/impl.clj
+++ b/src/stedi/jsii/alpha/impl.clj
@@ -1,9 +1,9 @@
-(ns stedi.cdk.alpha.jsii.impl
+(ns stedi.jsii.alpha.impl
   (:require [clojure.data.json :as json]
             [clojure.walk :as walk]
-            [stedi.cdk.alpha.jsii.assembly :as assm]
-            [stedi.cdk.alpha.jsii.client :as client]
-            [stedi.cdk.alpha.jsii.fqn :as fqn])
+            [stedi.jsii.alpha.assembly :as assm]
+            [stedi.jsii.alpha.client :as client]
+            [stedi.jsii.alpha.fqn :as fqn])
   (:import (software.amazon.jsii JsiiObjectRef)))
 
 (def ^:private valid-tokens

--- a/src/stedi/jsii/alpha/import.clj
+++ b/src/stedi/jsii/alpha/import.clj
@@ -1,10 +1,10 @@
-(ns stedi.cdk.alpha.jsii.import
+(ns stedi.jsii.alpha.import
   (:require [clojure.spec.test.alpha :as stest]
             [clojure.string :as string]
-            [stedi.cdk.alpha.jsii.assembly :as assm]
-            [stedi.cdk.alpha.jsii.fqn :as fqn]
-            [stedi.cdk.alpha.jsii.impl :as impl]
-            [stedi.cdk.alpha.jsii.spec :as spec]))
+            [stedi.jsii.alpha.assembly :as assm]
+            [stedi.jsii.alpha.fqn :as fqn]
+            [stedi.jsii.alpha.impl :as impl]
+            [stedi.jsii.alpha.spec :as spec]))
 
 (defn- arg-lists
   [parameters]

--- a/src/stedi/jsii/alpha/spec.clj
+++ b/src/stedi/jsii/alpha/spec.clj
@@ -1,9 +1,9 @@
-(ns stedi.cdk.alpha.jsii.spec
+(ns stedi.jsii.alpha.spec
   (:require [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as sgen]
-            [stedi.cdk.alpha.jsii.assembly :as assm]
-            [stedi.cdk.alpha.jsii.fqn :as fqn]
-            [stedi.cdk.alpha.jsii.impl :as impl]))
+            [stedi.jsii.alpha.assembly :as assm]
+            [stedi.jsii.alpha.fqn :as fqn]
+            [stedi.jsii.alpha.impl :as impl]))
 
 (s/def ::string-like
   (s/or :string string?
@@ -95,15 +95,16 @@
              :gen (partial gen-satisfies-interface ~fqn))))
 
 (defn- datatype-spec-definition
-  [{:keys [fqn properties] :as t}]
-  (let [req-un (into []
-                     (comp (remove :optional)
-                           (map (partial prop-spec-k t)))
-                     properties)
-        opt-un (into []
-                     (comp (filter :optional)
-                           (map (partial prop-spec-k t)))
-                     properties)]
+  [{:keys [fqn] :as t}]
+  (let [properties (assm/properties fqn)
+        req-un     (into []
+                         (comp (remove :optional)
+                               (map (partial prop-spec-k t)))
+                         properties)
+        opt-un     (into []
+                         (comp (filter :optional)
+                               (map (partial prop-spec-k t)))
+                         properties)]
     `(s/def ~(fqn/fqn->qualified-keyword fqn)
        (s/keys :req-un ~req-un
                :opt-un ~opt-un))))

--- a/test/stedi/jsii/alpha_test.clj
+++ b/test/stedi/jsii/alpha_test.clj
@@ -1,7 +1,7 @@
-(ns stedi.cdk.alpha.jsii-test
+(ns stedi.jsii.alpha-test
   (:require [clojure.spec.alpha :as s]
             [clojure.test :as t :refer [deftest testing is]]
-            [stedi.cdk.alpha.jsii :as jsii]))
+            [stedi.jsii.alpha :as jsii]))
 
 (jsii/import-fqn "@aws-cdk/core.App" 'App)
 (jsii/import-fqn "@aws-cdk/core.Stack" 'Stack)
@@ -9,11 +9,11 @@
 
 (deftest jsii-class-test
   (let [C (jsii/get-class "@aws-cdk/core.Stack")]
-    (is (instance? stedi.cdk.alpha.jsii.impl.JsiiClass C))
+    (is (instance? stedi.jsii.alpha.impl.JsiiClass C))
 
     (testing "invoking a class invokes the constructor"
       (let [stack (C)]
-        (is (instance? stedi.cdk.alpha.jsii.impl.JsiiObject stack))))
+        (is (instance? stedi.jsii.alpha.impl.JsiiObject stack))))
 
     (testing "classes extend ILookup for static property access"
       (is (:ACCOUNT_ID (jsii/get-class "@aws-cdk/core.Aws"))))))
@@ -33,12 +33,12 @@
 
   (testing "aliases created namespace to the specified symbol"
     (is (= (find-ns 'aws-cdk.core.App)
-           (-> (ns-aliases (find-ns 'stedi.cdk.alpha.jsii-test))
+           (-> (ns-aliases (find-ns 'stedi.jsii.alpha-test))
                (get 'App))))))
 
 (deftest importing-a-class-test
   (testing "refers a jsii class into the current namespace"
-    (is (instance? stedi.cdk.alpha.jsii.impl.JsiiClass App)))
+    (is (instance? stedi.jsii.alpha.impl.JsiiClass App)))
 
   (testing "interns class functions into created namespace"
     (let [interned-symbols
@@ -75,7 +75,7 @@
 
 (deftest importing-an-enum-test
   (testing "refers a jsii enum into the current namespace"
-    (is (instance? stedi.cdk.alpha.jsii.impl.JsiiEnumClass TagType)))
+    (is (instance? stedi.jsii.alpha.impl.JsiiEnumClass TagType)))
 
   (testing "interns enum members into created namespace"
     (let [interned-symbols
@@ -93,7 +93,7 @@
              interned-symbols))))
 
   (testing "interned members are enum members"
-    (is (instance? stedi.cdk.alpha.jsii.impl.JsiiEnumMember TagType/STANDARD))))
+    (is (instance? stedi.jsii.alpha.impl.JsiiEnumMember TagType/STANDARD))))
 
 (comment
   (t/run-tests)


### PR DESCRIPTION
Jsii is a layer that is independent to CDK and should be separated out
of the CDK tree and eventually broken out into its own library so it
can be used outside the context of CDK.