### PR TITLE
CLI improvements to make room for extension over time

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,8 @@
 {:paths   ["resources" "src"]
  :deps    {org.apache.commons/commons-compress {:mvn/version "1.19"}
            org.clojure/data.json               {:mvn/version "0.2.6"}
+           org.clojure/tools.cli               {:mvn/version "0.4.2"}
+           org.clojure/tools.namespace         {:mvn/version "0.3.1"}
            software.amazon.awscdk/core         {:mvn/version "1.16.3.DEVPREVIEW"}}
  :aliases {:dev  {:extra-paths ["test"]
                   :extra-deps  {clj-kondo                     {:mvn/version "2019.09.22-alpha"}

--- a/examples/basics/cdk.json
+++ b/examples/basics/cdk.json
@@ -1,1 +1,1 @@
-{"app":"clojure -A:dev -m stedi.cdk.main stedi.basics.cdk/app"}
+{"app":"clojure -C:dev -R:dev -m stedi.cdk.main synth"}

--- a/examples/basics/cdk/stedi/basics/cdk.clj
+++ b/examples/basics/cdk/stedi/basics/cdk.clj
@@ -75,7 +75,7 @@ App/synth
 ;; A stack needs at least one resource Construct in order to be
 ;; deployable so lets add a bucket.
 
-(cdk/import ["@aws-cdk/aws-s3" Bucket])
+(cdk/import [[Bucket] :from "@aws-cdk/aws-s3"])
 
 ;; cdk-clj generates specs for and instruments all jsii constructors
 ;; and functions:

--- a/examples/basics/deps.edn
+++ b/examples/basics/deps.edn
@@ -1,7 +1,8 @@
 {:paths   ["src"]
  :deps    {org.clojure/clojure {:mvn/version "1.10.1"}
            uswitch/lambada     {:mvn/version "0.1.2"}}
- :aliases {:classes {:extra-paths ["classes"]}
+ :aliases {:cdk     {:main-opts ["-m" "stedi.cdk.main"]}
+           :classes {:extra-paths ["classes"]}
            :dev     {:extra-paths ["cdk"]
                      :extra-deps  {software.amazon.awscdk/s3     {:mvn/version "1.16.3.DEVPREVIEW"}
                                    software.amazon.awscdk/lambda {:mvn/version "1.16.3.DEVPREVIEW"}

--- a/examples/depswatch/cdk.json
+++ b/examples/depswatch/cdk.json
@@ -1,1 +1,1 @@
-{"app":"clojure -A:dev -m stedi.cdk.main depswatch.cdk/app"}
+{"app":"clojure -C:dev -R:dev -m stedi.cdk.main synth"}

--- a/examples/depswatch/deps.edn
+++ b/examples/depswatch/deps.edn
@@ -3,7 +3,8 @@
 
          org.clojure/data.json {:mvn/version "0.2.6"}
          uswitch/lambada       {:mvn/version "0.1.2"}}
- :aliases {:classes {:extra-paths ["classes"]}
+ :aliases {:cdk     {:main-opts ["-m" "stedi.cdk.main"]}
+           :classes {:extra-paths ["classes"]}
            :dev     {:extra-paths ["cdk"]
                      :extra-deps  {stediinc/cdk-clj {:local/root "../../"}
 

--- a/src/stedi/cdk/alpha.clj
+++ b/src/stedi/cdk/alpha.clj
@@ -1,8 +1,6 @@
 (ns stedi.cdk.alpha
   (:refer-clojure :exclude [import])
-  (:require [clojure.data.json :as json]
-            [clojure.java.browse :as browse]
-            [clojure.java.io :as io]
+  (:require [clojure.java.browse :as browse]
             [clojure.spec.alpha :as s]
             [clojure.string :as string]
             [stedi.jsii.alpha :as jsii]))
@@ -96,8 +94,6 @@
   After declaring itself, the app extension instantiates itself which
   forces cdk validations to occur to streamline the repl-workflow.
 
-  Autogenerates a `cdk.json` file if it does not exist.
-
   Example:
 
   (cdk/defapp app
@@ -105,15 +101,9 @@
     (stack this \"MyDevStack\" {}))"
   [name args & body]
   (jsii/reset-runtime!)
-  (when-not (.exists (io/file "cdk.json"))
-    (spit "cdk.json"
-          (json/write-str
-            {:app (format "clojure -A:dev -m stedi.cdk.main %s"
-                          (str *ns* "/" name))}
-            :escape-slash false)))
   `(do (import [[~'App] :from "@aws-cdk/core"])
        (let [app# (~'App {})]
-       ((fn ~args ~@body) app#)
-       (def ~name
-         (doto app#
-           (App/synth))))))
+         ((fn ~args ~@body) app#)
+         (def ~name
+           (doto app#
+             (App/synth))))))

--- a/src/stedi/cdk/main.clj
+++ b/src/stedi/cdk/main.clj
@@ -1,10 +1,62 @@
 (ns stedi.cdk.main
-  (:require [stedi.cdk.alpha :as cdk]))
+  (:require [clojure.data.json :as json]
+            [clojure.java.classpath :as cp]
+            [clojure.tools.cli :as cli]
+            [clojure.tools.namespace.find :as ctn.find]
+            [stedi.cdk.alpha :as cdk]
+            [stedi.jsii.alpha :as jsii]))
 
 (cdk/import [[App] :from "@aws-cdk/core"])
 
-(defn -main [& [app-sym]]
-  (let [app @(requiring-resolve (symbol app-sym))]
-    (App/synth app))
-  (shutdown-agents)
-  (System/exit 0))
+(defn load-project-files
+  []
+  (->> (cp/classpath-directories)
+       (ctn.find/find-namespaces)
+       (map #(do (require %) %))
+       (doall)))
+
+(defn find-app
+  []
+  (let [apps (->> (load-project-files)
+                  (mapcat ns-publics)
+                  (map second)
+                  (filter (comp #(and (jsii/jsii-primitive? %)
+                                      (App/isApp %))
+                                deref)))]
+    (assert (not-empty apps) "No app was found.")
+    (assert (= 1 (count apps)) "More than one app was found.")
+    (deref (first apps))))
+
+(defn config
+  [{:keys [aliases]}]
+  (spit "cdk.json"
+        (json/write-str
+          {:app (str "clojure"
+                     (when aliases
+                       (str " -C:" aliases " -R:" aliases))
+                     " -m stedi.cdk.main synth")}
+          :escape-slash false)))
+
+(defn synth
+  [_]
+  (let [app (find-app)]
+    (App/synth app)))
+
+(def actions
+  {:config {:cli-options [[nil "--aliases ALIASES" "Colon seperated classpath aliases to use during synth"]]
+            :handler     config}
+   :synth  {:handler synth}})
+
+(defn do-main
+  [args]
+  (let [action-kw         (keyword (first args))
+        {:keys [cli-options
+                handler]} (get actions action-kw)
+        {:keys [options]} (cli/parse-opts args (or cli-options []))]
+    (handler options)))
+
+(defn -main [& args]
+  (try
+    (do-main args)
+    (finally
+      (shutdown-agents))))


### PR DESCRIPTION
CLI improvements to make room for extension over time

`stedi.cdk.main` had a single action before, which is prohibitive for
adding new functionality over time.

This change breaks that by turning `stedi.cdk.main` into a CLI
entrypoint with two actions:

- config: configures cdk.json to be used with cdk synth
- synth:  locates a `@aws-cdk/core.App` var and calls `synth` on it

Existing projects can be updated by calling:

``` clojure
clj -m stedi.cdk.main config --aliases <aliases to include while running synth>
```