### PR TITLE
Fix `json` type spec reference.

### DIFF
--- a/src/stedi/jsii/alpha/spec.clj
+++ b/src/stedi/jsii/alpha/spec.clj
@@ -14,8 +14,8 @@
         :int integer?
         :float float?
         :boolean boolean?
-        :vector (s/coll-of ::json-value :kind vector?)
-        :map (s/map-of ::string-like ::json-value)))
+        :vector (s/coll-of ::json :kind vector?)
+        :map (s/map-of ::string-like ::json)))
 
 (defn- metatype
   [{:keys [datatype kind]}]


### PR DESCRIPTION
Addresses:

```
1. Caused by java.lang.Exception
   Unable to resolve spec: :stedi.jsii.alpha.spec/json-value

                 alpha.clj:   69  clojure.spec.alpha/reg-resolve!
                 alpha.clj:   64  clojure.spec.alpha/reg-resolve!
```

E.g. https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_core.CfnInclude.html