### PR TITLE
Remove valid property guards.

### DIFF
--- a/src/stedi/jsii/alpha/impl.clj
+++ b/src/stedi/jsii/alpha/impl.clj
@@ -52,13 +52,7 @@
 (deftype JsiiObject [fqn interfaces objId]
   clojure.lang.ILookup
   (valAt [this k]
-    (let [valid-props (props this (complement :static))
-          value
-          (or (valid-props k)
-              (throw (ex-info "Invalid property"
-                              {:k           k
-                               :valid-props valid-props})))]
-      (->clj (client/get-property-value objId (name value)))))
+    (->clj (client/get-property-value objId (name k))))
 
   Invocable
   (-invoke [_ {:keys [op args]}]
@@ -97,13 +91,7 @@
 (deftype JsiiClass [fqn]
   clojure.lang.ILookup
   (valAt [this k]
-    (let [valid-props (props this :static)
-          value
-          (or (valid-props k)
-              (throw (ex-info "Invalid property"
-                              {:k           k
-                               :valid-props valid-props})))]
-      (->clj (client/get-static-property-value fqn (name value)))))
+    (->clj (client/get-static-property-value fqn (name k))))
 
   Invocable
   (-invoke [_ {:keys [op args]}]


### PR DESCRIPTION
Another consequence of the change to the way that JSii implements interfaces,
first referenced in f61eb15897cf025a6d9e9f5880d0ceb7ddd5b987.  These guards to
validate the properties don't correctly handle the case where the property is
defined by the interface that a class implements, not the class itself (as is
the case with [GitHubSourceAction].

The decision for now is to have cdk-clj behave more as a pass-through, and allow
the JSii errors to surface, rather than try to be smart and have to keep up with
these kinds of fundamental architectural changes in JSii.

[GitHubSourceAction]: https://docs.aws.amazon.com/cdk/api/latest/docs/@aws-cdk_aws-codepipeline-actions.GitHubSourceAction.html